### PR TITLE
Enable GitHub Pages deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ npm start
 The app will be available at [http://localhost:3000](http://localhost:3000).
 
 *Note: This project is for demo purposes and does not include persistent storage or authentication best practices.*
+
+## Deploying to GitHub Pages
+
+You can publish the static frontend from the `public` directory using GitHub Pages. After installing dependencies, run:
+
+```bash
+npm run deploy
+```
+
+This command uses the `gh-pages` package to push the contents of `public` to a `gh-pages` branch, making the site available at `https://<username>.github.io/<repository>`. The Express backend does not run on GitHub Pages, so dynamic features require running the server locally with `npm start`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "deploy": "gh-pages -d public"
   },
   "keywords": [],
   "author": "",
@@ -13,5 +14,8 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "gh-pages": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `gh-pages` as a dev dependency and a `deploy` script
- document how to publish the static frontend to GitHub Pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684378a34928832bb478ed52cf8d623e